### PR TITLE
skip http exception from bugsnag

### DIFF
--- a/src/Subscriber/BugsnagExceptionSubscriber.php
+++ b/src/Subscriber/BugsnagExceptionSubscriber.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -50,6 +51,10 @@ class BugsnagExceptionSubscriber implements EventSubscriberInterface
     public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         $exception = $event->getException();
+        //skip all exceptions that are thrown by us(of type HttpExceptionInterface)
+        if (false === ($exception instanceof HttpExceptionInterface)) {
+            return;
+        }
 
         $this->client->notifyException($exception);
     }


### PR DESCRIPTION
## What does this PR contains ?
1- skip any exception of type HttpExceptionInterface from being sent to bugsnag
## Steps to test
1- add "lamsa/api-core": "^5.0" to your composer.json (inside your symfony project)
2- execute composer update
3- throw exception of type HttpExceptionInterface
4- check bugsnag dashboard, event should not be sent