### PR TITLE
fix skipping issue

### DIFF
--- a/src/Subscriber/BugsnagExceptionSubscriber.php
+++ b/src/Subscriber/BugsnagExceptionSubscriber.php
@@ -52,8 +52,8 @@ class BugsnagExceptionSubscriber implements EventSubscriberInterface
     {
         $exception = $event->getException();
         //skip all exceptions that are thrown by us(of type HttpExceptionInterface)
-        if (false === ($exception instanceof HttpExceptionInterface)) {
-            return;
+        if(true === ($exception instanceof HttpExceptionInterface)) {
+            return ;
         }
 
         $this->client->notifyException($exception);


### PR DESCRIPTION
## What does this PR contains ?
1- fix skip any exception of type HttpExceptionInterface from being sent to bugsnag
## Steps to test
1- add "lamsa/api-core": "^5.0" to your composer.json (inside your symfony project)
2- execute composer update
3- throw exception of type HttpExceptionInterface
4- check bugsnag dashboard, event should not be sent