### PR TITLE
support translation

### DIFF
--- a/src/Subscriber/RequestSubscriber.php
+++ b/src/Subscriber/RequestSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * api-core - RequestSubscriber.php
+ *
+ * Date: 7/9/18
+ * Time: 12:46 PM
+ * @author    Abdelhameed Alasbahi <abdkwa92@gmail.com>
+ * @copyright Copyright (c) 2018 LamsaWorld (http://www.lamsaworld.com/)
+ */
+
+namespace Lamsa\ApiCore\Subscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Class RequestSubscriber
+ * @package Lamsa\ApiCore\Subscriber
+ */
+class RequestSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $locale  = $request->headers->get('locale');
+        $request->setLocale($locale);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}

--- a/tests/Subscriber/ApiExceptionSubscriberTest.php
+++ b/tests/Subscriber/ApiExceptionSubscriberTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class ApiExceptionSubscriberTest
@@ -38,6 +39,11 @@ class ApiExceptionSubscriberTest extends TestCase
      * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $loggerMock;
+
+    /**
+     * @var TranslatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $translator;
 
     /**
      * @var HttpKernelInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -61,14 +67,13 @@ class ApiExceptionSubscriberTest extends TestCase
     {
         $this->viewHandlerMock = $this->getMockBuilder(ViewHandlerInterface::class)
             ->getMock();
-
         $this->loggerMock     = $this->getMockBuilder(LoggerInterface::class)
+            ->getMock();
+        $this->translator     = $this->getMockBuilder(TranslatorInterface::class)
             ->getMock();
         $this->httpKernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
-
         $this->formErrorConverter = new FormErrorConverter();
-
         $this->formConfigMock = $this->getMockBuilder(FormConfigInterface::class)
             ->getMock();
     }
@@ -84,8 +89,12 @@ class ApiExceptionSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('handle')
             ->willReturn($response);
+        $this->translator
+            ->expects($this->once())
+            ->method('trans')
+            ->willReturn("message key");
 
-        $ApiExceptionSubscriber = new ApiExceptionSubscriber($this->viewHandlerMock, $this->loggerMock, $this->formErrorConverter);
+        $ApiExceptionSubscriber = new ApiExceptionSubscriber($this->viewHandlerMock, $this->loggerMock, $this->formErrorConverter,$this->translator);
         $exception              = new  InvalidFormException(new Form($this->formConfigMock));
 
         $event = new GetResponseForExceptionEvent($this->httpKernelMock, new Request(), 'json', $exception);
@@ -100,7 +109,7 @@ class ApiExceptionSubscriberTest extends TestCase
      */
     public function testOnApiExceptionWithoutHttpException()
     {
-        $ApiExceptionSubscriber = new ApiExceptionSubscriber($this->viewHandlerMock, $this->loggerMock, $this->formErrorConverter);
+        $ApiExceptionSubscriber = new ApiExceptionSubscriber($this->viewHandlerMock, $this->loggerMock, $this->formErrorConverter,$this->translator);
         $exception              = new  \Exception('test');
 
         $event = new GetResponseForExceptionEvent($this->httpKernelMock, new Request(), 'json', $exception);


### PR DESCRIPTION
## What does this PR contains ?
1- support translation for form errors and HttpInterfaceExceptions
## Steps to test
1- add "lamsa/api-core": "^7.0" to your composer.json (inside your symfony project)
2- execute composer update
3- add translation folder to your service with messages.en.yml and messages.ar.yml
4- add locale to request header
5- throw exception of type HttpExceptionInterface